### PR TITLE
Re #3: Reworked shell identification

### DIFF
--- a/prompt.sh
+++ b/prompt.sh
@@ -1,11 +1,11 @@
 function under_bash () {
-	[[ "`ps -p $$ | tail -1|awk '{print $NF}'`" == "-bash" ]] 2>&1 && return
-	return 1
+	[[ "`ps -p $$ | tail -1| grep -o 'bash$'`" == "bash" ]] 2>&1 && return
+    return 1
 }
 
 function under_zsh () {
-	[[ "`ps -p $$ | tail -1|awk '{print $NF}'`" == "-zsh" ]] 2>&1 && return
-	return 1
+	[[ "`ps -p $$ | tail -1| grep -o 'zsh$'`" == "zsh" ]] 2>&1 && return
+    return 1
 }
 
 msrp_color_red=$'\e[31m'


### PR DESCRIPTION
Hi, I don't make pull requests too often, hope this way is okay.
I reworked shell identification and tested it on both bash and zsh on Macbook and Mint Linux. Identification seems to work fine now. Please have a look if this also works for you.
The multi-shell-repo-prompt is not working for me, though (I'm normally a bash user), so I'm not sure what's up with that (the prompt in zsh on Macbook is literally "$(construct_prompt)$msrp_reset_color").
