### PR TITLE
Fix `renamed` in prompt.sh

### DIFF
--- a/prompt.sh
+++ b/prompt.sh
@@ -219,7 +219,7 @@ function repo_status {
 			if [[ "$changes" != "" ]]; then
 				changes="${changes}, "
 			fi
-			changes="${changes}${removed} renamed"
+			changes="${changes}${renamed} renamed"
 		fi
 		
 		# missing file count


### PR DESCRIPTION
Not sure how this bug has gone unnoticed for so long. I guess nobody `git mv`s things!
